### PR TITLE
ci: fix cargo-fmt failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           rustup show
           echo "=== Available components ==="
           rustup component list
+          echo "=== Installed components ==="
+          rustup component list --installed
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,28 @@ jobs:
     timeout-minutes: 10
     needs: pre_job
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v4
+      - name: Debug Rust toolchain info
+        run: |
+          echo "=== Rustup version ==="
+          rustup --version
+          echo "=== Rustc version ==="
+          rustc --version
+          echo "=== Default toolchain ==="
+          rustup show
+          echo "=== Available components ==="
+          rustup component list
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Debug after toolchain setup
+        run: |
+          echo "=== After toolchain setup ==="
+          rustc --version
+          rustup show
+          echo "=== Installed components ==="
+          rustup component list --installed
       - run: cargo fmt --all -- --check
 
   lints:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,28 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Debug Rust toolchain info
-        run: |
-          echo "=== Rustup version ==="
-          rustup --version
-          echo "=== Rustc version ==="
-          rustc --version
-          echo "=== Default toolchain ==="
-          rustup show
-          echo "=== Available components ==="
-          rustup component list
-          echo "=== Installed components ==="
-          rustup component list --installed
-      # - uses: dtolnay/rust-toolchain@nightly
-      #   with:
-      #     components: rustfmt
-      # - name: Debug after toolchain setup
-      #   run: |
-      #     echo "=== After toolchain setup ==="
-      #     rustc --version
-      #     rustup show
-      #     echo "=== Installed components ==="
-      #     rustup component list --installed
+      - run: rustup update # For some reason cargo-fmt doesn't give rustup time to auto-install.
       - run: cargo fmt --all -- --check
 
   lints:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,16 @@ jobs:
           rustup component list
           echo "=== Installed components ==="
           rustup component list --installed
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - name: Debug after toolchain setup
-        run: |
-          echo "=== After toolchain setup ==="
-          rustc --version
-          rustup show
-          echo "=== Installed components ==="
-          rustup component list --installed
+      # - uses: dtolnay/rust-toolchain@nightly
+      #   with:
+      #     components: rustfmt
+      # - name: Debug after toolchain setup
+      #   run: |
+      #     echo "=== After toolchain setup ==="
+      #     rustc --version
+      #     rustup show
+      #     echo "=== Installed components ==="
+      #     rustup component list --installed
       - run: cargo fmt --all -- --check
 
   lints:


### PR DESCRIPTION
It seems, for some reason, that running `cargo fmt` doesn't cause `rustup` to auto-update, so we need to just poke `rustup` manually